### PR TITLE
Add regulatory risk dashboard script and sample profile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,10 @@
 *.o
 *.so
 
+# Python cache files
+__pycache__/
+*.py[cod]
+
 # Packages #
 ############
 # it's better to unpack these files and commit the raw source

--- a/README.md
+++ b/README.md
@@ -10,6 +10,21 @@ Remember, it's self-paced so feel free to take a break! ☕️
 
 [![](https://img.shields.io/badge/Go%20to%20Exercise-%E2%86%92-1f883d?style=for-the-badge&logo=github&labelColor=197935)](https://github.com/joyroy0521/skills-introduction-to-github/issues/1)
 
+## Regulatory Dashboard
+
+This repository also includes a simple dashboard that analyses an organisation's
+profile (geography, industry, products and suppliers) and lists relevant
+regulatory categories and potential risks.
+
+Run it with:
+
+```bash
+python regulatory_dashboard.py sample_profile.json
+```
+
+Modify `sample_profile.json` with your own data to evaluate different
+scenarios.
+
 ---
 
 &copy; 2025 GitHub &bull; [Code of Conduct](https://www.contributor-covenant.org/version/2/1/code_of_conduct/code_of_conduct.md) &bull; [MIT License](https://gh.io/mit)

--- a/regulatory_dashboard.py
+++ b/regulatory_dashboard.py
@@ -1,0 +1,78 @@
+"""Simple dashboard for regulatory analysis.
+
+This script loads an organization profile from JSON and prints
+regulatory categories and risks based on geography, industry,
+products, and suppliers.
+"""
+import json
+import sys
+from collections import defaultdict
+
+# Mapping of profile aspects to regulatory categories and risks
+GEOGRAPHY_RULES = {
+    "USA": {"categories": ["OSHA", "EPA"], "risks": ["labor", "environment"]},
+    "EU": {"categories": ["GDPR", "REACH"], "risks": ["privacy", "chemical"]},
+    "Asia": {"categories": ["APAC Trade"], "risks": ["import/export"]},
+}
+
+INDUSTRY_RULES = {
+    "finance": {"categories": ["SOX"], "risks": ["fraud"]},
+    "manufacturing": {"categories": ["ISO9001"], "risks": ["quality"]},
+}
+
+PRODUCT_RULES = {
+    "electronics": {"categories": ["WEEE"], "risks": ["e-waste"]},
+    "food": {"categories": ["FDA"], "risks": ["contamination"]},
+}
+
+SUPPLIER_RULES = {
+    "chemical": {"categories": ["Hazmat"], "risks": ["hazardous materials"]},
+    "software": {"categories": ["Licensing"], "risks": ["intellectual property"]},
+}
+
+RULESETS = {
+    "geography": GEOGRAPHY_RULES,
+    "industry": INDUSTRY_RULES,
+    "products": PRODUCT_RULES,
+    "suppliers": SUPPLIER_RULES,
+}
+
+def analyze_profile(profile: dict) -> dict:
+    """Return regulatory categories and risks for a profile.
+
+    The result is a dict with two keys, ``categories`` and ``risks``,
+    each containing a sorted list of unique values.
+    """
+    categories = set()
+    risks = set()
+
+    for key, rules in RULESETS.items():
+        values = profile.get(key, [])
+        for value in values:
+            info = rules.get(value, {})
+            categories.update(info.get("categories", []))
+            risks.update(info.get("risks", []))
+
+    return {
+        "categories": sorted(categories),
+        "risks": sorted(risks),
+    }
+
+def main(path: str) -> None:
+    with open(path, "r", encoding="utf-8") as f:
+        profile = json.load(f)
+
+    result = analyze_profile(profile)
+    print("Regulatory categories needed:")
+    for cat in result["categories"]:
+        print(f" - {cat}")
+
+    print("\nPotential regulatory risks:")
+    for risk in result["risks"]:
+        print(f" - {risk}")
+
+if __name__ == "__main__":
+    if len(sys.argv) < 2:
+        print("Usage: python regulatory_dashboard.py <profile.json>")
+        sys.exit(1)
+    main(sys.argv[1])

--- a/sample_profile.json
+++ b/sample_profile.json
@@ -1,0 +1,7 @@
+{
+  "name": "Acme Corp",
+  "geography": ["USA", "EU"],
+  "industry": ["finance"],
+  "products": ["electronics"],
+  "suppliers": ["chemical"]
+}


### PR DESCRIPTION
## Summary
- add `regulatory_dashboard.py` to analyze organization geography, industry, products, and suppliers for regulatory categories and risks
- include `sample_profile.json` and README instructions
- ignore Python cache directories

## Testing
- `python -m py_compile regulatory_dashboard.py`
- `python regulatory_dashboard.py sample_profile.json`

------
https://chatgpt.com/codex/tasks/task_e_68b9d06545dc832b9fc631951bc8c2f3