### PR TITLE
Add PFAS reporting MVP system

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,35 @@ python regulatory_dashboard.py sample_profile.json
 Modify `sample_profile.json` with your own data to evaluate different
 scenarios.
 
+## PFAS Reporting MVP
+
+The repository now contains a reference implementation of a PFAS reporting
+workflow inspired by the business requirements document in this exercise.
+It ingests supplier declarations from a CSV file and produces a JSON report
+aligned to EPA TSCA §8(a)(7) field names.
+
+Run it with:
+
+```bash
+python pfas_reporting.py sample_suppliers.csv report.json --pfas-dict pfas_list.txt
+```
+
+The generated `report.json` summarises supplier responses and lists mapped
+declarations ready for further processing or submission.
+
+## PFAS Reporting Frontend
+
+This repository includes a minimal Flask web interface for generating reports from the browser.
+
+Run it with:
+
+```bash
+python -m pip install flask
+python pfas_frontend.py
+```
+
+Open <http://127.0.0.1:5000> and upload the supplier CSV and optional PFAS dictionary to receive the JSON report.
+
 ---
 
 &copy; 2025 GitHub &bull; [Code of Conduct](https://www.contributor-covenant.org/version/2/1/code_of_conduct/code_of_conduct.md) &bull; [MIT License](https://gh.io/mit)

--- a/pfas_frontend.py
+++ b/pfas_frontend.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+import csv
+import io
+from typing import List
+
+from flask import Flask, jsonify, render_template_string, request
+
+from pfas_reporting import PFASDictionary, ReportGenerator, SupplierDeclaration
+
+app = Flask(__name__)
+
+FORM_HTML = """
+<!doctype html>
+<title>PFAS Reporter</title>
+<h1>PFAS Reporting</h1>
+<form method="post" enctype="multipart/form-data">
+  <label>Supplier CSV: <input type="file" name="csv" required></label><br>
+  <label>PFAS Dictionary (optional): <input type="file" name="pfas_dict"></label><br>
+  <input type="submit" value="Generate Report">
+</form>
+"""
+
+
+def _load_declarations_from_csv(data: str) -> List[SupplierDeclaration]:
+    reader = csv.DictReader(io.StringIO(data))
+    return [SupplierDeclaration.from_row(row) for row in reader]
+
+
+def _apply_dictionary(declarations: List[SupplierDeclaration], dictionary: PFASDictionary) -> None:
+    for decl in declarations:
+        if decl.pfas_presence.lower() == "unknown":
+            if any(name in decl.article_description.lower() for name in dictionary.entries):
+                decl.pfas_presence = "Yes"
+
+
+@app.route("/", methods=["GET", "POST"])
+def index():
+    if request.method == "POST":
+        csv_file = request.files.get("csv")
+        if not csv_file:
+            return "CSV file is required", 400
+        csv_text = csv_file.stream.read().decode("utf-8")
+        declarations = _load_declarations_from_csv(csv_text)
+
+        dict_file = request.files.get("pfas_dict")
+        if dict_file:
+            dict_text = dict_file.stream.read().decode("utf-8")
+            dictionary = PFASDictionary(dict_text.splitlines())
+            _apply_dictionary(declarations, dictionary)
+
+        report = ReportGenerator(declarations).generate()
+        return jsonify(report)
+
+    return render_template_string(FORM_HTML)
+
+
+if __name__ == "__main__":
+    app.run(debug=True)

--- a/pfas_list.txt
+++ b/pfas_list.txt
@@ -1,0 +1,3 @@
+firefighting foam
+ptfe
+perfluorooctanoic acid

--- a/pfas_reporting.py
+++ b/pfas_reporting.py
@@ -1,0 +1,179 @@
+"""PFAS reporting system for SMEs.
+
+This module implements a minimal portion of the PFAS Reporting MVP
+outlined in the business requirements document (BRD).  It supports
+loading supplier declarations from a CSV file, matching entries against
+an internal PFAS substance dictionary, and generating a simple report
+pack that mirrors fields required for EPA TSCA §8(a)(7) submissions.
+
+The intent is to serve as a reference implementation for a more
+comprehensive system that would include supplier outreach workflows,
+audit trails, evidence management, and Microsoft integration.
+"""
+
+from __future__ import annotations
+
+import csv
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable, List, Dict, Any
+
+# ---------------------------------------------------------------------------
+# Data model
+# ---------------------------------------------------------------------------
+
+@dataclass
+class SupplierDeclaration:
+    """Supplier-provided information for an article or substance.
+
+    This structure roughly follows the fields in the Streamlined Form for
+    article importers (Appendix A.2).
+    """
+
+    company_name: str
+    contact_name: str
+    email: str
+    article_description: str
+    pfas_presence: str  # Yes / No / Unknown
+    kra_basis: str
+    evidence: str | None = None
+    cbi_claim: bool = False
+
+    @classmethod
+    def from_row(cls, row: Dict[str, str]) -> "SupplierDeclaration":
+        """Create a declaration from a CSV row."""
+        return cls(
+            company_name=row.get("Company Name", "").strip(),
+            contact_name=row.get("Contact Name", "").strip(),
+            email=row.get("Email Address", "").strip(),
+            article_description=row.get("Article Description", "").strip(),
+            pfas_presence=row.get("PFAS Presence", "Unknown").strip(),
+            kra_basis=row.get("Known or Reasonably Ascertainable Basis", "").strip(),
+            evidence=row.get("Evidence", "").strip() or None,
+            cbi_claim=row.get("CBI Claim", "").strip().lower() in {"true", "yes", "1"},
+        )
+
+
+# ---------------------------------------------------------------------------
+# PFAS dictionary and matching
+# ---------------------------------------------------------------------------
+
+class PFASDictionary:
+    """Simple in-memory dictionary of PFAS substances.
+
+    In a production system this could be backed by a SharePoint list or a
+    database table.  For the MVP we load substances from a plain-text file
+    where each line contains a CAS registry number or substance name.
+    """
+
+    def __init__(self, entries: Iterable[str]):
+        self.entries = {e.strip().lower() for e in entries if e.strip()}
+
+    @classmethod
+    def from_file(cls, path: Path) -> "PFASDictionary":
+        with open(path, "r", encoding="utf-8") as f:
+            return cls(f.readlines())
+
+    def contains(self, substance: str) -> bool:
+        return substance.lower().strip() in self.entries
+
+
+# ---------------------------------------------------------------------------
+# Report generation
+# ---------------------------------------------------------------------------
+
+class ReportGenerator:
+    """Generate report packs for EPA submission.
+
+    The generator produces a JSON document that maps internal fields to
+    the EPA field names outlined in Appendix B.
+    """
+
+    def __init__(self, declarations: Iterable[SupplierDeclaration]):
+        self.declarations = list(declarations)
+
+    def response_rate(self) -> float:
+        """Return the fraction of suppliers that provided a PFAS answer."""
+        answered = sum(1 for d in self.declarations if d.pfas_presence)
+        total = len(self.declarations) or 1
+        return answered / total
+
+    def generate(self) -> Dict[str, Any]:
+        mapped: List[Dict[str, Any]] = []
+        for d in self.declarations:
+            mapped.append(
+                {
+                    "Reporting Entity Name": d.company_name,
+                    "Contact Name": d.contact_name,
+                    "Email": d.email,
+                    "Article Description": d.article_description,
+                    "PFAS Presence": d.pfas_presence,
+                    "Known or Reasonably Ascertainable Basis": d.kra_basis,
+                    "Evidence": d.evidence,
+                    "CBI Claim": d.cbi_claim,
+                }
+            )
+
+        return {
+            "summary": {
+                "supplier_count": len(self.declarations),
+                "response_rate": self.response_rate(),
+            },
+            "declarations": mapped,
+        }
+
+    def write(self, path: Path) -> None:
+        data = self.generate()
+        with open(path, "w", encoding="utf-8") as f:
+            json.dump(data, f, indent=2)
+
+
+# ---------------------------------------------------------------------------
+# CSV ingestion helper
+# ---------------------------------------------------------------------------
+
+
+def load_declarations(csv_path: Path) -> List[SupplierDeclaration]:
+    """Read declarations from a CSV file."""
+    with open(csv_path, "r", encoding="utf-8", newline="") as f:
+        reader = csv.DictReader(f)
+        return [SupplierDeclaration.from_row(row) for row in reader]
+
+
+# ---------------------------------------------------------------------------
+# CLI entry point
+# ---------------------------------------------------------------------------
+
+
+def main(csv_path: str, report_path: str, dict_path: str | None = None) -> None:
+    declarations = load_declarations(Path(csv_path))
+
+    if dict_path:
+        dictionary = PFASDictionary.from_file(Path(dict_path))
+        for decl in declarations:
+            if decl.pfas_presence.lower() == "unknown":
+                # Very naive matching: check if the description contains any
+                # PFAS substance name from the dictionary.
+                if any(name in decl.article_description.lower() for name in dictionary.entries):
+                    decl.pfas_presence = "Yes"
+
+    report = ReportGenerator(declarations)
+    report.write(Path(report_path))
+    print(f"Generated report with {len(declarations)} suppliers -> {report_path}")
+
+
+if __name__ == "__main__":
+    import argparse
+
+    parser = argparse.ArgumentParser(description="PFAS Reporting MVP")
+    parser.add_argument("csv", help="Path to supplier declaration CSV")
+    parser.add_argument("output", help="Path to JSON report to create")
+    parser.add_argument(
+        "--pfas-dict",
+        dest="pfas_dict",
+        help="Optional path to PFAS substance dictionary (one entry per line)",
+    )
+    args = parser.parse_args()
+
+    main(args.csv, args.output, args.pfas_dict)

--- a/sample_suppliers.csv
+++ b/sample_suppliers.csv
@@ -1,0 +1,4 @@
+Company Name,Contact Name,Email Address,Article Description,PFAS Presence,Known or Reasonably Ascertainable Basis,Evidence,CBI Claim
+Acme Co,Jane Doe,jane@example.com,Firefighting Foam,Unknown,Not provided,,False
+Globex Corp,John Smith,john@globex.com,Non-stick Pan,No,Supply chain disclosure,,False
+Initech,Peter Gibbons,peter@initech.com,Waterproof Jacket,Unknown,Awaiting lab results,,True


### PR DESCRIPTION
## Summary
- add a simple PFAS reporting script that ingests supplier declarations and emits an EPA-aligned JSON report
- document usage of the PFAS reporter and include sample CSV and PFAS dictionary
- add a minimal Flask web front end for uploading supplier data and generating reports

## Testing
- `python -m py_compile pfas_frontend.py`
- `python -m py_compile pfas_reporting.py`
- `python pfas_reporting.py sample_suppliers.csv report.json --pfas-dict pfas_list.txt`


------
https://chatgpt.com/codex/tasks/task_e_68c06a93d608832ba7629edaca370df8